### PR TITLE
Configures automated NPM publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish to NPM
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [created]
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to NPM
+        if: github.event_name == 'release'
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to NPM (beta)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          npm version prerelease --preid=beta --no-git-tag-version
+          npm publish --tag beta --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,29 @@
+# Source
+src/
+tests/
+__tests__/
+*.test.ts
+
+# Config files
+tsconfig.json
+jest.config.js
+.github/
+.gitignore
+.npmignore
+.dockerignore
+
+# Docker
+Dockerfile
+docker-compose.yml
+
+# Development
+node_modules/
+coverage/
+.vscode/
+.idea/
+*.log
+*.tgz
+
+# Environment
+.env
+.env.* 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,19 @@ A Cursor MCP extension for notifying code reviewers about pull requests that nee
 
 ## Installation
 
-### Option 1: Docker Installation (Recommended)
+### Option 1: NPM Installation (Recommended)
 
-The easiest way to install and run this MCP extension is using Docker:
+```bash
+# Install the stable version
+npm install @cursor/mcp-notify-reviewers
+
+# Or install the beta version for latest features
+npm install @cursor/mcp-notify-reviewers@beta
+```
+
+### Option 2: Docker Installation
+
+The easiest way to run this MCP extension is using Docker:
 
 1. Clone this repository:
    ```bash
@@ -42,7 +52,7 @@ To stop the service:
 docker-compose down
 ```
 
-### Option 2: Local Development
+### Option 3: Local Development
 1. Clone this repository
 2. Install dependencies:
 ```bash
@@ -57,7 +67,7 @@ npm run build
 npm start
 ```
 
-### Option 3: Manual Installation in Cursor MCP
+### Option 4: Manual Installation in Cursor MCP
 
 To manually install this extension in Cursor's MCP system:
 
@@ -147,6 +157,23 @@ npm test
 ```bash
 npm run build
 ```
+
+## Publishing
+
+This package is automatically published to npm using GitHub Actions:
+
+- When a new release is created on GitHub, a stable version is published to npm
+- When changes are pushed to the main branch, a beta version is published to npm
+
+To publish a new version:
+
+1. For stable releases:
+   - Create a new release on GitHub
+   - The workflow will automatically publish to npm
+
+2. For beta releases:
+   - Push changes to the main branch
+   - The workflow will automatically publish a beta version to npm
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,35 @@
 {
-  "name": "mcp-notify-reviewers",
+  "name": "@cursor/mcp-notify-reviewers",
   "version": "1.0.0",
   "description": "MCP extension for notifying code reviewers in Cursor",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "prepublishOnly": "npm test && npm run build"
   },
-  "keywords": ["cursor", "mcp", "code-review"],
+  "keywords": ["cursor", "mcp", "code-review", "github", "pull-request"],
   "author": "",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yourusername/mcp-notify-reviewers.git"
+  },
+  "bugs": {
+    "url": "https://github.com/yourusername/mcp-notify-reviewers/issues"
+  },
+  "homepage": "https://github.com/yourusername/mcp-notify-reviewers#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5"


### PR DESCRIPTION
Sets up GitHub Actions workflow to automatically publish the package to NPM on releases and pushes to the main branch.

This allows for both stable and beta releases to be published automatically, improving the release process and ensuring that the package is always up-to-date on NPM.

Also updates the README with instructions for installing stable and beta versions. Adds .npmignore to exclude unnecessary files from the published package. Adds metadata to package.json.